### PR TITLE
Fix astropy version to satisfy pycbc==1.8.0 from hypothesis==0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+astropy==5.0.4
 matplotlib
 torch
 papermill


### PR DESCRIPTION
By default, `pip` installs `astropy` version that is not compatible with `pycbc==1.8.0` enforced in this repo by `c57ea562bb0bd14d22da9ff67d36a95695da148f` revision of `hypothesis`

https://github.com/gwastro/pycbc/issues/4035 suggest setting `astropy==5.0.4`