### PR TITLE
Do not overwrite dependencies in `train_and_evaluate`

### DIFF
--- a/workflows/bnre/pipeline.py
+++ b/workflows/bnre/pipeline.py
@@ -224,7 +224,8 @@ def merge_blocks(directory, dependencies):
 
 
 def train_and_evaluate(budget, batch_size, dependencies=None):
-    dependencies = []
+    if dependencies is None:
+        dependencies = []
 
     root = problem + '/output/estimator/' + str(budget) + '/' + str(batch_size) + '/' + str(learning_rate)
     if arguments.gamma is None:

--- a/workflows/nre/pipeline.py
+++ b/workflows/nre/pipeline.py
@@ -192,7 +192,8 @@ def merge_blocks(directory, dependencies):
 
 
 def train_and_evaluate(budget, batch_size, dependencies=None):
-    dependencies = []
+    if dependencies is None:
+        dependencies = []
     root = problem + '/output/estimator/' + str(budget) + '/' + str(batch_size) + '/' + str(learning_rate)
     os.makedirs(root, exist_ok=True)
 


### PR DESCRIPTION
The current implementation of `train_and_evaluate` ignores the dependencies. Consequently, the generated data is not collected from `blocks,` and the whole code crushes.